### PR TITLE
make Sos::from_vec() publicly available

### DIFF
--- a/src/sos.rs
+++ b/src/sos.rs
@@ -73,7 +73,8 @@ impl Sos {
         self.sections.len()
     }
 
-    fn from_vec(vec: Vec<[f64;6]>) -> Self {
+    /// Create from a vector containing an array for each section.
+    pub fn from_vec(vec: Vec<[f64; 6]>) -> Self {
         let mut sections: Vec<SosCoeffs> = vec![];
 
         for s_array in vec.iter() {


### PR DESCRIPTION
This allows for custom filter coefficients to be created.

I stumbled across your crate while trying to implement butterworth filters in Rust.
Thank you for creating this crate and saving me and others a lot of work.

As I also need to filter data with specific Sos coefficients, I propose this change to be able to create a Sos struct with custom coefficients.

Let me know what you think.